### PR TITLE
add batch_squared_norm to kornia/geometry/linalg __all__

### DIFF
--- a/kornia/geometry/linalg.py
+++ b/kornia/geometry/linalg.py
@@ -13,6 +13,7 @@ __all__ = [
     "transform_points",
     "point_line_distance",
     "squared_norm",
+    "batched_squared_norm",
     "batched_dot_product",
     "euclidean_distance",
 ]


### PR DESCRIPTION
#### Changes
```python
from kornia.geometry.linalg import *
squared_norm(...)  # works
batched_squared_norm(...)  # doesn't work
```
I don't know the purpose of this alias, but it seems weird creating an alias and not adding the original to `__all__`
#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
